### PR TITLE
Refresh UTXO, do not execute actions twice

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -46,6 +46,7 @@ interface TomlConfig {
     bitcoin?: BitcoinConfig;
     ethereum?: EthereumConfig;
   };
+  maxRetries?: number;
 }
 
 export class Config {
@@ -68,8 +69,11 @@ export class Config {
   public seed: Buffer;
   public bitcoinConfig?: BitcoinConfig;
   public ethereumConfig?: EthereumConfig;
+  public maxRetries: number;
 
   constructor(tomlConfig: TomlConfig) {
+    this.maxRetries = tomlConfig.maxRetries ? tomlConfig.maxRetries : 10;
+
     const ledgers = throwIfFalse(tomlConfig, "ledgers");
     this.bitcoinConfig = ledgers.bitcoin;
     this.ethereumConfig = ledgers.ethereum;

--- a/src/ledgerExecutor.ts
+++ b/src/ledgerExecutor.ts
@@ -127,12 +127,11 @@ export class LedgerExecutor implements ILedgerExecutor {
     const parameters = {
       gasPrice,
       gasLimit: params.gasLimit,
-      to: params.to
+      to: params.to,
+      data: params.data ? hexToBuffer(params.data) : undefined
     };
-    if (params.data) {
-      Object.assign(params, { data: hexToBuffer(params.data) });
-    }
-    log(`Invoking sendTransaction on Ethereum Wallet with ${parameters}`);
+
+    log("Invoking sendTransaction on Ethereum Wallet with ", parameters);
     return ethereumWallet.sendTransactionTo(parameters);
   }
 

--- a/src/wallets/bitcoin.ts
+++ b/src/wallets/bitcoin.ts
@@ -174,6 +174,7 @@ export class InternalBitcoinWallet implements BitcoinWallet {
     log("Fee (sats):", fee);
 
     if (!inputs || !outputs) {
+      log("Was not able to fund the transaction");
       throw new Error("Was not able to fund the transaction");
     }
 

--- a/tests/config.spec.ts
+++ b/tests/config.spec.ts
@@ -119,7 +119,7 @@ describe("Config tests", () => {
     expect(config.getBuyDivBySellRate("dogecoin", "ether")).toBeUndefined();
   });
 
-  it("should parse the config with correct fee strategy slected", () => {
+  it("should parse the config with correct fee strategy selected", () => {
     const config = Config.fromFile("./tests/configs/default.toml");
 
     expect(config.bitcoinConfig).toBeDefined();
@@ -136,5 +136,10 @@ describe("Config tests", () => {
       defaultFee: 10,
       strategy: "average"
     });
+  });
+
+  it("should parse the config with correct maximum retries", () => {
+    const config = Config.fromFile("./tests/configs/default.toml");
+    expect(config.maxRetries).toEqual(20);
   });
 });

--- a/tests/configs/default.toml
+++ b/tests/configs/default.toml
@@ -1,5 +1,6 @@
 comitNodeUrl = "http://localhost:8000"
 seedWords = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon"
+maxRetries = 20
 
 [rates.ether.bitcoin]
 # Aiming for a "centralised exchange" feeling

--- a/tests/stubs/redeemEther.json
+++ b/tests/stubs/redeemEther.json
@@ -4,6 +4,7 @@
     "contract_address": "0x1189128ff5573f6282dbbf1557ed839dab277aeb",
     "gas_limit": "0x186a0",
     "min_block_timestamp": 1557504724,
-    "network": "regtest"
+    "network": "regtest",
+    "data": "0x00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff"
   }
 }


### PR DESCRIPTION
- Do not **execute** actions twice
- Re-execute action if the execution failed
- Improve logging
- Refresh Bitcoin Wallet UTXOs
- Ensure data is passed for Ethereum tx