### PR TITLE
Sub-satoshis

### DIFF
--- a/src/bitcoin/blockchain.ts
+++ b/src/bitcoin/blockchain.ts
@@ -24,7 +24,11 @@ export class Satoshis {
     }
 
     if (!Number.isInteger(sats)) {
-      throw new Error("Only integer Satoshis are supported");
+      // `scantxoutset` somehow returned a strange value that is not a satoshi integer
+      // Could not reproduce the issue but better put a fail-safe and use a satoshi than
+      // Break
+      log(`non-integer satoshi: ${sats}`);
+      sats = Math.floor(sats);
     }
 
     return new Satoshis(sats);

--- a/tests/bitcoin/blockchain.spec.ts
+++ b/tests/bitcoin/blockchain.spec.ts
@@ -1,0 +1,21 @@
+import { Satoshis } from "../../src/bitcoin/blockchain";
+
+describe("Test bitcoin blockchain module", () => {
+  it("Correctly parses string of float Bitcoin to Satoshis", () => {
+    const sats = Satoshis.fromBitcoin("00010.00009");
+
+    expect(sats.getSatoshis()).toEqual(1000009000);
+  });
+
+  it("Correctly parses float Bitcoin to Satoshis", () => {
+    const sats = Satoshis.fromBitcoin(123.12345678);
+
+    expect(sats.getSatoshis()).toEqual(12312345678);
+  });
+
+  it("rounds down if float bitcoin is sub-satoshi", () => {
+    const sats = Satoshis.fromBitcoin(123.123456789);
+
+    expect(sats.getSatoshis()).toEqual(12312345678);
+  });
+});


### PR DESCRIPTION
During the workshop somehow a UTXO returned by bitcoind was sub-satoshi.
Throwing an exception meant that the bitcoin UTXO scan was simply not processed.
Instead, we log and we just accept to loose under a satoshi for the sake of robustness.