### PR TITLE
Use `reduce` instead of mutable variable

### DIFF
--- a/src/wallets/bitcoin.ts
+++ b/src/wallets/bitcoin.ts
@@ -134,14 +134,16 @@ export class InternalBitcoinWallet implements BitcoinWallet {
   }
 
   public getNominalBalance(): Big {
-    let satBalance = new Big(0);
-    this.unspentOutputs.forEach((utxo: CsUtxo) => {
-      satBalance = satBalance.add(utxo.value);
-    });
+    const satBalance = Array.from(this.unspentOutputs.values()).reduce(
+      (sum, next) => sum.add(next.value),
+      new Big(0)
+    );
+
     const bitcoinBalance = toNominalUnit(Asset.Bitcoin, satBalance);
     if (!bitcoinBalance) {
       throw new Error("Internal Error: Bitcoin is not supported?");
     }
+
     return bitcoinBalance;
   }
 


### PR DESCRIPTION
This way, we don't have to pass an impure closure around but can just sum up the UTXOs right away.