### PR TITLE
Favor destructing objects to avoid local variables

### DIFF
--- a/tests/actionSelector.spec.ts
+++ b/tests/actionSelector.spec.ts
@@ -161,23 +161,28 @@ describe("Action selector tests: ", () => {
   it("Should emit refund first then redeem action", async done => {
     const actionSelector = new ActionSelector(config, rates);
 
-    const redeemEntityAndAction = extractEntityAndAction(
-      swapsRedeemRefundStub,
-      "redeem"
-    );
-    const refundEntityAndAction = extractEntityAndAction(
-      swapsRedeemRefundStub,
-      "refund"
-    );
+    {
+      const { entity, action } = extractEntityAndAction(
+        swapsRedeemRefundStub,
+        "refund"
+      );
 
-    const actionResponse1 = await actionSelector.selectActions(
-      refundEntityAndAction.entity
-    );
-    expect(actionResponse1).toStrictEqual(refundEntityAndAction.action);
-    const actionResponse2 = await actionSelector.selectActions(
-      redeemEntityAndAction.entity
-    );
-    expect(actionResponse2).toStrictEqual(redeemEntityAndAction.action);
+      const actionResponse = await actionSelector.selectActions(entity);
+
+      expect(actionResponse).toStrictEqual(action);
+    }
+
+    {
+      const { entity, action } = extractEntityAndAction(
+        swapsRedeemRefundStub,
+        "redeem"
+      );
+
+      const actionResponse = await actionSelector.selectActions(entity);
+
+      expect(actionResponse).toStrictEqual(action);
+    }
+
     done();
   });
 });


### PR DESCRIPTION
By using two distinct scopes, we can avoid the local variables and use destruction same as in the other tests. This makes the tests more consistent then thus, hopefully easier to understand.