### PR TITLE
Rename `getRateService` to `create...`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import { Config } from "./config";
 import { EthereumGasPriceService } from "./ethereum/ethereumGasPriceService";
 import { DefaultFieldDataSource } from "./fieldDataSource";
 import { LedgerExecutor } from "./ledgerExecutor";
-import { getRateService } from "./rates/tradeEvaluationService";
+import { createTradeEvaluationService } from "./rates/tradeEvaluationService";
 import { InternalBitcoinWallet } from "./wallets/bitcoin";
 import { Web3EthereumWallet } from "./wallets/ethereum";
 
@@ -77,7 +77,7 @@ const config = Config.fromFile("./config.toml");
   } = await initBitcoin(config);
   const ethereumParams = await initEthereum(config);
 
-  const tradeEvaluationService = getRateService({
+  const tradeEvaluationService = createTradeEvaluationService({
     config,
     ethereumWallet: ethereumParams.ethereumWallet,
     bitcoinWallet

--- a/src/rates/tradeEvaluationService.ts
+++ b/src/rates/tradeEvaluationService.ts
@@ -25,7 +25,7 @@ export interface InitialiseRateParameters {
   ethereumWallet?: EthereumWallet;
   bitcoinWallet?: BitcoinWallet;
 }
-export function getRateService({
+export function createTradeEvaluationService({
   config,
   ethereumWallet,
   bitcoinWallet

--- a/tests/rates/tradeEvaluationService.spec.ts
+++ b/tests/rates/tradeEvaluationService.spec.ts
@@ -1,7 +1,7 @@
 import Big from "big.js";
 import BN = require("bn.js");
 import { Config } from "../../src/config";
-import { getRateService } from "../../src/rates/tradeEvaluationService";
+import { createTradeEvaluationService } from "../../src/rates/tradeEvaluationService";
 import BitcoinWalletStub from "../doubles/bitcoinWalletStub";
 import EthereumWalletStub from "../doubles/ethereumWalletStub";
 
@@ -17,7 +17,7 @@ describe("Test TradeEvaluationService module", () => {
   it("should load the static rate if present in configuration", () => {
     const config = Config.fromFile("./tests/configs/staticRates.toml");
     console.log(config);
-    const rates = getRateService({
+    const rates = createTradeEvaluationService({
       config,
       bitcoinWallet,
       ethereumWallet
@@ -28,7 +28,7 @@ describe("Test TradeEvaluationService module", () => {
 
   it("should set the marketmaker if no rates defined in the config", () => {
     const config = Config.fromFile("./tests/configs/testnetMarketMaker.toml");
-    const rates = getRateService({
+    const rates = createTradeEvaluationService({
       config,
       bitcoinWallet,
       ethereumWallet
@@ -80,7 +80,7 @@ describe("Test TradeEvaluationService module", () => {
     });
 
     expect(() => {
-      getRateService({
+      createTradeEvaluationService({
         config,
         bitcoinWallet,
         ethereumWallet
@@ -118,7 +118,7 @@ describe("Test TradeEvaluationService module", () => {
     });
 
     expect(() =>
-      getRateService({
+      createTradeEvaluationService({
         config,
         bitcoinWallet,
         ethereumWallet


### PR DESCRIPTION
By convention, a "Getter" is usually cheap and doesn't do much, hence we rename the factory method for creating a new instance of the TradeEvaluationService to `createTradeEvaluationService` to convey that we are _creating_ a new instance here and not just returning (getting) an already existing one.