### PR TITLE
Use `calculate` as the verb in `getAmountsToCalculate`

### DIFF
--- a/src/rates/testnetMarketMaker.ts
+++ b/src/rates/testnetMarketMaker.ts
@@ -66,7 +66,7 @@ export default class TestnetMarketMaker implements TradeEvaluationService {
    * @param {string} sellAsset The asset to sell
    * @return {buyNominalAmount: number, sellNominalAmount: number} The buy and sell amounts to publish (in nominal)
    */
-  public async getAmountsToPublish(
+  public async calculateAmountsToPublish(
     buyAsset: Asset,
     sellAsset: Asset
   ): Promise<{ buyNominalAmount: Big; sellNominalAmount: Big }> {

--- a/tests/rates/testnetMarketMaker.spec.ts
+++ b/tests/rates/testnetMarketMaker.spec.ts
@@ -36,7 +36,10 @@ describe("Test the TestnetMarketMaker module", () => {
       { rateSpread: 5, publishFraction: 200, maxFraction: 100 },
       createMockBalanceLookups(100, 1000)
     );
-    const amounts = await marketMaker.getAmountsToPublish(buyAsset, sellAsset);
+    const amounts = await marketMaker.calculateAmountsToPublish(
+      buyAsset,
+      sellAsset
+    );
     expect(amounts).toBeDefined();
     const {
       // @ts-ignore: amounts are defined
@@ -54,7 +57,7 @@ describe("Test the TestnetMarketMaker module", () => {
       createMockBalanceLookups(100, 0)
     );
     await expect(
-      marketMaker.getAmountsToPublish(Asset.Bitcoin, Asset.Ether)
+      marketMaker.calculateAmountsToPublish(Asset.Bitcoin, Asset.Ether)
     ).rejects.toThrowError("Insufficient funds");
   });
 
@@ -79,7 +82,10 @@ describe("Test the TestnetMarketMaker module", () => {
       { rateSpread: 5, publishFraction: 200, maxFraction: 100 },
       createMockBalanceLookups(100, 1000)
     );
-    const amounts = await marketMaker.getAmountsToPublish(buyAsset, sellAsset);
+    const amounts = await marketMaker.calculateAmountsToPublish(
+      buyAsset,
+      sellAsset
+    );
     expect(amounts).toBeDefined();
     const {
       // @ts-ignore: amounts are defined
@@ -103,7 +109,10 @@ describe("Test the TestnetMarketMaker module", () => {
       createMockBalanceLookups(100, 1000)
     );
 
-    const amounts = await marketMaker.getAmountsToPublish(buyAsset, sellAsset);
+    const amounts = await marketMaker.calculateAmountsToPublish(
+      buyAsset,
+      sellAsset
+    );
     expect(amounts).toBeDefined();
     const {
       // @ts-ignore: amounts are defined


### PR DESCRIPTION
"Get" conveys the meaning of returning something that is already stored. This is not what we are doing. We "calculate" those amounts and hence should convey that to the caller.