### PR TITLE
Introduce resolveOrReject analogous to returnOrThrow

### DIFF
--- a/tests/doubles/bitcoinWalletStub.ts
+++ b/tests/doubles/bitcoinWalletStub.ts
@@ -2,20 +2,21 @@ import Big from "big.js";
 import { Network } from "bitcoinjs-lib";
 import { Satoshis } from "../../src/bitcoin/blockchain";
 import { BitcoinWallet } from "../../src/wallets/bitcoin";
+import resolveOrReject from "./resolveOrReject";
 import returnOrThrow from "./returnOrThrow";
 
 interface BitcoinWalletStubArgs {
   network?: Network;
   address?: string;
   payToAdressTransactionId?: string;
-  nominalBalance?: number;
+  nominalBalance?: Big;
 }
 
 export default class BitcoinWalletStub implements BitcoinWallet {
   public readonly network?: Network;
   public readonly address?: string;
   public readonly payToAdressTransactionId?: string;
-  public readonly nominalBalance?: number;
+  public readonly nominalBalance?: Big;
 
   constructor({
     network,
@@ -45,7 +46,7 @@ export default class BitcoinWalletStub implements BitcoinWallet {
     // @ts-ignore
     feeSatPerByte: Satoshis
   ): Promise<string> {
-    return returnOrThrow(this, "payToAdressTransactionId");
+    return resolveOrReject(this, "payToAdressTransactionId");
   }
 
   public getNominalBalance(): Big {

--- a/tests/doubles/ethereumWalletStub.ts
+++ b/tests/doubles/ethereumWalletStub.ts
@@ -6,20 +6,21 @@ import {
   SendTransactionToParams,
   SharedTransactionParams
 } from "../../src/wallets/ethereum";
+import resolveOrReject from "./resolveOrReject";
 import returnOrThrow from "./returnOrThrow";
 
 interface EthereumWalletStubArgs {
   address?: string;
   deployContractReceipt?: TransactionReceipt;
   sendTransactionToReceipt?: TransactionReceipt;
-  nominalBalance?: number;
+  nominalBalance?: Big;
 }
 
 export default class EthereumWalletStub implements EthereumWallet {
   public readonly address?: string;
   public readonly deployContractReceipt?: TransactionReceipt;
   public readonly sendTransactionToReceipt?: TransactionReceipt;
-  public readonly nominalBalance?: number;
+  public readonly nominalBalance?: Big;
 
   constructor({
     address,
@@ -37,7 +38,7 @@ export default class EthereumWalletStub implements EthereumWallet {
     // @ts-ignore
     params: SharedTransactionParams & DeployContractParams
   ): Promise<TransactionReceipt> {
-    return returnOrThrow(this, "deployContractReceipt");
+    return resolveOrReject(this, "deployContractReceipt");
   }
 
   public getAddress(): string {
@@ -45,13 +46,13 @@ export default class EthereumWalletStub implements EthereumWallet {
   }
 
   public getNominalBalance(): Promise<Big> {
-    return returnOrThrow(this, "nominalBalance");
+    return resolveOrReject(this, "nominalBalance");
   }
 
   public sendTransactionTo(
     // @ts-ignore
     params: SharedTransactionParams & SendTransactionToParams
   ): Promise<TransactionReceipt> {
-    return returnOrThrow(this, "sendTransactionToReceipt");
+    return resolveOrReject(this, "sendTransactionToReceipt");
   }
 }

--- a/tests/doubles/resolveOrReject.ts
+++ b/tests/doubles/resolveOrReject.ts
@@ -1,0 +1,14 @@
+export default function returnOrThrow<T extends object>(
+  instance: T,
+  field: keyof T
+): Promise<any> {
+  const candidate = instance[field];
+
+  if (candidate) {
+    return Promise.resolve(candidate);
+  } else {
+    return Promise.reject(
+      `Mock ${instance.constructor.name} was not configured to return ${field}`
+    );
+  }
+}

--- a/tests/rates/tradeEvaluationService.spec.ts
+++ b/tests/rates/tradeEvaluationService.spec.ts
@@ -1,3 +1,4 @@
+import Big from "big.js";
 import BN = require("bn.js");
 import { Config } from "../../src/config";
 import { getRateService } from "../../src/rates/tradeEvaluationService";
@@ -6,11 +7,11 @@ import EthereumWalletStub from "../doubles/ethereumWalletStub";
 
 describe("Test TradeEvaluationService module", () => {
   const bitcoinWallet = new BitcoinWalletStub({
-    nominalBalance: 1
+    nominalBalance: new Big(1)
   });
 
   const ethereumWallet = new EthereumWalletStub({
-    nominalBalance: 1
+    nominalBalance: new Big(1)
   });
 
   it("should load the static rate if present in configuration", () => {


### PR DESCRIPTION
This allows us to conveniently stub out methods of stubs that return a Promise. Methods that return a Promise should not throw but return a rejected Promise.