### PR TITLE
Include error objects in log statements

### DIFF
--- a/src/bitcoin/bitcoinFeeService.ts
+++ b/src/bitcoin/bitcoinFeeService.ts
@@ -41,9 +41,10 @@ export class BitcoinFeeService {
       return fee;
     } catch (err) {
       logger.info(
-        `Could not retrieve fees from Bitcoin feeservice: ${err}, falling back to default fee ${
+        `Could not retrieve fees from Bitcoin feeservice, falling back to default fee ${
           this.defaultFee
-        }`
+        }`,
+        err
       );
       return this.defaultFee;
     }

--- a/src/ethereum/ethereumGasPriceService.ts
+++ b/src/ethereum/ethereumGasPriceService.ts
@@ -37,8 +37,11 @@ export class EthereumGasPriceService {
       }
       return new BN(gasPrice);
     } catch (err) {
-      logger.info(`Could not retrieve fees from Ethereum feeservice: ${err}, 
-        falling back to default gas price ${this.defaultGasPrice}`);
+      logger.info(
+        `Could not retrieve fees from Ethereum feeservice, 
+        falling back to default gas price ${this.defaultGasPrice}`,
+        err
+      );
       return this.defaultGasPrice;
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -126,9 +126,7 @@ const config = Config.fromFile("./config.toml");
           logger.trace(`No action returned for swap ${id}`);
         }
       } catch (err) {
-        logger.error(
-          `Error has occurred for swap ${id}. Error is: ${JSON.stringify(err)}`
-        );
+        logger.error(`Error has occurred for swap ${id}`, err);
       }
     }
   };

--- a/src/rates/tradeEvaluationService.ts
+++ b/src/rates/tradeEvaluationService.ts
@@ -46,7 +46,7 @@ export function createTradeEvaluationService({
           return bitcoinWallet.getNominalBalance();
         }
       } catch (e) {
-        logger.error("Bitcoin balance not found");
+        logger.error("Bitcoin balance not found", e);
       }
 
       return Promise.resolve(new Big(0));
@@ -57,7 +57,7 @@ export function createTradeEvaluationService({
         try {
           return ethereumWallet.getNominalBalance();
         } catch (e) {
-          logger.error("Ethereum balance not found");
+          logger.error("Ethereum balance not found", e);
         }
       }
       return Promise.resolve(new Big(0));


### PR DESCRIPTION
Error objects include useful information like stacktraces which can greatly help in diagnosing problems. We should always include those as separate arguments in the log messages and leave the formatting to the log framework / appender otherwise we lose the stacktrace information.