### PR TITLE
Add test with unsupported erc20 token

### DIFF
--- a/tests/actionSelector.spec.ts
+++ b/tests/actionSelector.spec.ts
@@ -4,6 +4,7 @@ import { ActionSelector } from "../src/actionSelector";
 import { Config, TomlConfig } from "../src/config";
 import StaticRates, { ConfigRates } from "../src/rates/staticRates";
 import swapsAcceptDeclineStub from "./stubs/bitcoinEther/swapsWithAcceptDecline.siren.json";
+import swapsErc20AcceptDeclineStub from "./stubs/bitcoinEther/swapsWithErc20AcceptDecline.siren.json";
 import swapsRedeemBitcoinEther from "./stubs/bitcoinEther/swapsWithRedeem.siren.json";
 import swapsFundEtherBitcoinStub from "./stubs/etherBitcoin/swapsWithFund.siren.json";
 import swapsRedeemRefundStub from "./stubs/etherBitcoin/swapsWithRedeemRefund.siren.json";
@@ -86,6 +87,18 @@ describe("Action selector tests: ", () => {
     const actionSelector = new ActionSelector(config, rates);
     const { entity, action } = extractEntityAndAction(
       swapsAcceptDeclineStub,
+      "decline"
+    );
+
+    const actionResponse = await actionSelector.selectActions(entity);
+    expect(actionResponse).toStrictEqual(action);
+    done();
+  });
+
+  it("Should emit decline because of unsupported trading pair", async done => {
+    const actionSelector = new ActionSelector(config, rates);
+    const { entity, action } = extractEntityAndAction(
+      swapsErc20AcceptDeclineStub,
       "decline"
     );
 

--- a/tests/stubs/bitcoinEther/swapsWithErc20AcceptDecline.siren.json
+++ b/tests/stubs/bitcoinEther/swapsWithErc20AcceptDecline.siren.json
@@ -1,0 +1,76 @@
+{
+  "class": ["swaps"],
+  "entities": [
+    {
+      "class": ["swap"],
+      "rel": ["item"],
+      "properties": {
+        "role": "Alice",
+        "protocol": "rfc003",
+        "status": "IN_PROGRESS",
+        "id": "399e8ff5-9729-479e-aad8-49b03f8fc5d5",
+        "counterparty": "QmPRNaiDUcJmnuJWUyoADoqvFotwaMRFKV2RyZ7ZVr1fqd",
+        "parameters": {
+          "alpha_asset": {
+            "name": "bitcoin",
+            "quantity": "100000000"
+          },
+          "alpha_ledger": {
+            "name": "bitcoin",
+            "network": "regtest"
+          },
+          "beta_asset": {
+            "name": "erc20",
+            "quantity": "1000000000000",
+            "token_contract": "0xB97048628DB6B661D4C2aA833e95Dbe1A905B280"
+          },
+          "beta_ledger": {
+            "name": "ethereum",
+            "network": "regtest"
+          }
+        }
+      },
+      "links": [
+        {
+          "rel": ["self"],
+          "href": "/swaps/rfc003/399e8ff5-9729-479e-aad8-49b03f8fc5d5"
+        },
+        {
+          "rel": ["human-protocol-spec"],
+          "href": "https://github.com/comit-network/RFCs/blob/master/RFC-003-SWAP-Basic.md"
+        }
+      ],
+      "actions": [
+        {
+          "name": "accept",
+          "title": "Accept",
+          "method": "POST",
+          "href": "/swaps/rfc003/399e8ff5-9729-479e-aad8-49b03f8fc5d5/accept",
+          "type": "application/json",
+          "fields": [
+            {
+              "name": "beta_ledger_refund_identity",
+              "title": "Refund address on Ethereum",
+              "type": "text",
+              "class": ["address", "ethereum"]
+            }
+          ]
+        },
+        {
+          "name": "decline",
+          "title": "Decline",
+          "method": "POST",
+          "href": "/swaps/rfc003/399e8ff5-9729-479e-aad8-49b03f8fc5d5/decline",
+          "type": "application/json",
+          "fields": []
+        }
+      ]
+    }
+  ],
+  "links": [
+    {
+      "rel": ["self"],
+      "href": "/swaps"
+    }
+  ]
+}


### PR DESCRIPTION
Bobtimus does indeed decline ERC20 request. 
It does this only because calling `toAsset` returns undefined... I think this is fine for now. 

https://github.com/coblox/bobtimus/blob/e9fee39dc3157b4bfc075a2772688f0fc00846a6/src/asset.ts#L11-L21

Done because of #59