### PR TITLE
Fix timeout crash

### DIFF
--- a/src/bitcoin/bitcoinCoreRpc.ts
+++ b/src/bitcoin/bitcoinCoreRpc.ts
@@ -85,6 +85,10 @@ export class BitcoinCoreRpc implements BitcoinBlockchain {
   }
 
   public async findHdOutputs(extendedPublicKeys: string[]): Promise<Utxo[]> {
+    logger.debug(
+      "Starting `scantxoutset` which is a long blocking non-cached call"
+    );
+
     const scanobjects = extendedPublicKeys.map(exPubKey => {
       logger.info(`Send ${exPubKey} to bitcoind for scanning`);
       return {
@@ -93,9 +97,6 @@ export class BitcoinCoreRpc implements BitcoinBlockchain {
       };
     });
 
-    logger.debug(
-      "Starting `scantxoutset` which is a long blocking non-cached call"
-    );
     const result = await this.bitcoinClient.command(
       "scantxoutset",
       "start",

--- a/src/index.ts
+++ b/src/index.ts
@@ -187,7 +187,9 @@ const config = Config.fromFile("./config.toml");
   }, pollIntervalMillis);
 
   if (bitcoinWallet) {
-    await refreshUtxos(bitcoinWallet);
+    setTimeout(async () => {
+      await refreshUtxos(bitcoinWallet);
+    }, 10);
     setInterval(async () => {
       await refreshUtxos(bitcoinWallet);
     }, 60000);

--- a/src/index.ts
+++ b/src/index.ts
@@ -187,9 +187,8 @@ const config = Config.fromFile("./config.toml");
   }, pollIntervalMillis);
 
   if (bitcoinWallet) {
-    setTimeout(async () => {
-      await refreshUtxos(bitcoinWallet);
-    }, 10);
+    refreshUtxos(bitcoinWallet);
+
     setInterval(async () => {
       await refreshUtxos(bitcoinWallet);
     }, 60000);

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,15 @@ configure("./logconfig.json");
 
 const api = express();
 
+const refreshUtxos = async (bitcoinWallet: InternalBitcoinWallet) => {
+  try {
+    await bitcoinWallet.refreshUtxo();
+  } catch (e) {
+    logger.error("Failed to refresh UTXO:", e.message);
+    console.log(e.message);
+  }
+};
+
 const initBitcoin = async (config: Config) => {
   if (!config.bitcoinConfig) {
     return {
@@ -177,16 +186,11 @@ const config = Config.fromFile("./config.toml");
     );
   }, pollIntervalMillis);
 
-  try {
-    if (bitcoinWallet) {
-      await bitcoinWallet.refreshUtxo();
-      setInterval(() => {
-        bitcoinWallet.refreshUtxo();
-      }, 60000);
-    }
-  } catch (e) {
-    logger.error("Failed to refresh UTXO:", e.message);
-    console.log(e.message);
+  if (bitcoinWallet) {
+    await refreshUtxos(bitcoinWallet);
+    setInterval(async () => {
+      await refreshUtxos(bitcoinWallet);
+    }, 60000);
   }
 
   if (config.apiPort) {

--- a/tests/wallets/ethereum.spec.ts
+++ b/tests/wallets/ethereum.spec.ts
@@ -67,7 +67,7 @@ describe("Ethereum Wallet", () => {
 
       expect(balanceAfter).toEqual(expectedBalance);
     }),
-    20000
+    50000
   );
 
   test(


### PR DESCRIPTION
I thought I made this PR some time ago already.... 

anyway, right now, if the first UTXO scan crashes or runs in a timeout, it won't be repeated.
I extracted the scanning in an own function an additionally call it async so that processing index.js continues. 