### PR TITLE
Make `Asset` a class

### DIFF
--- a/src/actionSelector.ts
+++ b/src/actionSelector.ts
@@ -82,6 +82,7 @@ export class ActionSelector {
     const betaLedger = toLedger(swap.properties.parameters.beta_ledger.name);
     const alphaAsset = toAsset(swap.properties.parameters.alpha_asset.name);
     const betaAsset = toAsset(swap.properties.parameters.beta_asset.name);
+    const protocol = swap.properties.protocol;
 
     if (!alphaAsset || !betaAsset || !alphaLedger || !betaLedger) {
       return Promise.resolve(false);
@@ -119,7 +120,8 @@ export class ActionSelector {
         asset: betaAsset,
         ledger: betaLedger,
         quantity: betaNominalAmount
-      }
+      },
+      protocol
     };
 
     return this.rates.isTradeAcceptable(trade);

--- a/src/asset.ts
+++ b/src/asset.ts
@@ -1,19 +1,28 @@
 import Big from "big.js";
 import { getLogger } from "log4js";
+import Ledger from "./ledger";
 
 const logger = getLogger();
 
-enum Asset {
-  Bitcoin = "bitcoin",
-  Ether = "ether"
+class Asset {
+  public static bitcoin = new Asset("bitcoin", Ledger.Bitcoin);
+  public static ether = new Asset("ether", Ledger.Ethereum);
+
+  public ledger: Ledger;
+  public name: string;
+
+  public constructor(name: string, ledger: Ledger) {
+    this.name = name;
+    this.ledger = ledger;
+  }
 }
 
-export function toAsset(asset: string) {
+export function toAsset(asset: string): Asset | undefined {
   switch (asset) {
-    case Asset.Bitcoin:
-      return Asset.Bitcoin;
-    case Asset.Ether:
-      return Asset.Ether;
+    case Asset.bitcoin.name:
+      return Asset.bitcoin;
+    case Asset.ether.name:
+      return Asset.ether;
     default:
       logger.error(`Asset not supported: ${asset}`);
       return undefined;
@@ -24,12 +33,12 @@ export default Asset;
 
 export function toNominalUnit(asset: Asset, quantity: Big) {
   switch (asset) {
-    case Asset.Bitcoin: {
+    case Asset.bitcoin: {
       const sats = new Big(quantity);
       const satsInBitcoin = new Big("100000000");
       return sats.div(satsInBitcoin);
     }
-    case Asset.Ether: {
+    case Asset.ether: {
       const wei = new Big(quantity);
       const weiInEther = new Big("1000000000000000000");
       return wei.div(weiInEther);

--- a/src/ledger.ts
+++ b/src/ledger.ts
@@ -1,5 +1,4 @@
 import { getLogger } from "log4js";
-import Asset from "./asset";
 
 const logger = getLogger();
 
@@ -17,17 +16,6 @@ export function toLedger(ledger: string) {
     default:
       logger.error(`Ledger not supported: ${ledger}`);
       return undefined;
-  }
-}
-
-export function forAsset(asset: Asset) {
-  switch (asset) {
-    case Asset.Bitcoin:
-      return Ledger.Bitcoin;
-    case Asset.Ether:
-      return Ledger.Ethereum;
-    default:
-      throw new Error(`No ledger configured for asset ${asset}`);
   }
 }
 

--- a/src/rates/staticRates.ts
+++ b/src/rates/staticRates.ts
@@ -6,9 +6,13 @@ import { Trade, TradeService } from "./tradeService";
 
 const logger = getLogger();
 
-export type ConfigRates = {
-  [buyAsset in Asset]: { [sellAsset in Asset]?: number };
-};
+interface SubRate {
+  [sellAsset: string]: number;
+}
+
+export interface ConfigRates {
+  [buyAsset: string]: SubRate;
+}
 
 export default class StaticRates implements TradeService {
   private readonly configRates: ConfigRates;
@@ -17,7 +21,7 @@ export default class StaticRates implements TradeService {
   }
 
   public isTradeAcceptable({ buy, sell }: Trade) {
-    const rate = this.configRates[buy.asset][sell.asset];
+    const rate = this.configRates[buy.asset.name][sell.asset.name];
 
     if (!rate) {
       logger.warn(
@@ -45,12 +49,12 @@ export default class StaticRates implements TradeService {
         timestamp: new Date(),
         buy: {
           ledger: Ledger.Bitcoin,
-          asset: Asset.Bitcoin,
+          asset: Asset.bitcoin,
           quantity: new Big(1)
         },
         sell: {
           ledger: Ledger.Ethereum,
-          asset: Asset.Ether,
+          asset: Asset.ether,
           quantity: new Big(BTC_ETH)
         }
       },
@@ -59,12 +63,12 @@ export default class StaticRates implements TradeService {
         timestamp: new Date(),
         buy: {
           ledger: Ledger.Ethereum,
-          asset: Asset.Ether,
+          asset: Asset.ether,
           quantity: new Big(1)
         },
         sell: {
           ledger: Ledger.Bitcoin,
-          asset: Asset.Bitcoin,
+          asset: Asset.bitcoin,
           quantity: new Big(ETH_BTC)
         }
       }

--- a/src/rates/testnetMarketMaker.ts
+++ b/src/rates/testnetMarketMaker.ts
@@ -1,7 +1,6 @@
 import Big from "big.js";
 import { getLogger } from "log4js";
 import Asset from "../asset";
-import { forAsset } from "../ledger";
 import Balances from "./balances";
 import { Trade, TradeService } from "./tradeService";
 
@@ -75,7 +74,7 @@ export default class TestnetMarketMaker implements TradeService {
     const sufficientFunds = await this.balances.isSufficientFunds(sellAsset);
     if (!sufficientFunds) {
       throw new Error(
-        `Insufficient funding of asset ${sellAsset} to publish trades`
+        `Insufficient funding of asset ${sellAsset.name} to publish trades`
       );
     }
 
@@ -91,12 +90,12 @@ export default class TestnetMarketMaker implements TradeService {
       timestamp: new Date(),
       buy: {
         asset: buyAsset,
-        ledger: forAsset(buyAsset),
+        ledger: buyAsset.ledger,
         quantity: buyAmount
       },
       sell: {
         asset: sellAsset,
-        ledger: forAsset(sellAsset),
+        ledger: sellAsset.ledger,
         quantity: sellBalance.div(this.publishFraction)
       }
     };
@@ -153,10 +152,10 @@ export default class TestnetMarketMaker implements TradeService {
     const trades = new Array<Trade>();
 
     trades.push(
-      await this.prepareTradesToPublishForAsset(Asset.Bitcoin, Asset.Ether)
+      await this.prepareTradesToPublishForAsset(Asset.bitcoin, Asset.ether)
     );
     trades.push(
-      await this.prepareTradesToPublishForAsset(Asset.Ether, Asset.Bitcoin)
+      await this.prepareTradesToPublishForAsset(Asset.ether, Asset.bitcoin)
     );
 
     return trades;

--- a/src/rates/tradeService.ts
+++ b/src/rates/tradeService.ts
@@ -19,7 +19,7 @@ export interface TradeAmount {
 }
 
 export interface Trade {
-  protocol?: string;
+  protocol: string;
   timestamp: Date;
   buy: TradeAmount;
   sell: TradeAmount;

--- a/src/routes/tradesToPublish.ts
+++ b/src/routes/tradesToPublish.ts
@@ -10,6 +10,33 @@ const logger = getLogger();
 
 const previousTradesLookup: Map<string, Trade> = new Map<string, Trade>();
 
+export interface LedgerToPublish {
+  name: string;
+  network: string;
+}
+
+export interface RateToPublish {
+  buy: {
+    asset: string;
+    ledger: string;
+    quantity: string;
+  };
+  protocol: string;
+  sell: {
+    asset: string;
+    ledger: string;
+    quantity: string;
+  };
+  timestamp: string;
+}
+
+export interface ToPublish {
+  peerId: string;
+  addressHint: string | undefined;
+  ledgers: LedgerToPublish[];
+  rates: RateToPublish[];
+}
+
 export function getAmountsToPublishRoute(
   tradeService: TradeService,
   bitcoinConfig: BitcoinConfig,
@@ -29,7 +56,7 @@ export function getAmountsToPublishRoute(
 
       const trades = await tradeService.prepareTradesToPublish();
 
-      const publishTradesResponse = {
+      const publishTradesResponse: ToPublish = {
         peerId,
         addressHint,
         ledgers: [
@@ -48,12 +75,12 @@ export function getAmountsToPublishRoute(
             protocol: trade.protocol,
             buy: {
               ledger: trade.buy.ledger,
-              asset: trade.buy.asset,
+              asset: trade.buy.asset.name,
               quantity: trade.buy.quantity.toString()
             },
             sell: {
               ledger: trade.sell.ledger,
-              asset: trade.sell.asset,
+              asset: trade.sell.asset.name,
               quantity: trade.sell.quantity.toString()
             }
           };

--- a/src/wallets/bitcoin.ts
+++ b/src/wallets/bitcoin.ts
@@ -139,7 +139,7 @@ export class InternalBitcoinWallet implements BitcoinWallet {
       new Big(0)
     );
 
-    const bitcoinBalance = toNominalUnit(Asset.Bitcoin, satBalance);
+    const bitcoinBalance = toNominalUnit(Asset.bitcoin, satBalance);
     if (!bitcoinBalance) {
       throw new Error("Internal Error: Bitcoin is not supported?");
     }

--- a/src/wallets/ethereum.ts
+++ b/src/wallets/ethereum.ts
@@ -131,7 +131,7 @@ export class Web3EthereumWallet implements EthereumWallet {
 
   public async getNominalBalance() {
     const wei = await this.web3.eth.getBalance(this.account);
-    const ether = toNominalUnit(Asset.Ether, new Big(wei));
+    const ether = toNominalUnit(Asset.ether, new Big(wei));
     if (!ether) {
       throw new Error(`Failed to convert balance '${wei}' to a number`);
     }

--- a/tests/rates/balances.spec.ts
+++ b/tests/rates/balances.spec.ts
@@ -25,14 +25,14 @@ describe("Balances tests", () => {
       lowFundsThresholdPercentage
     );
 
-    expect(await balances.getBalance(Asset.Bitcoin)).toEqual(new Big(1));
-    expect(await balances.getBalance(Asset.Ether)).toEqual(new Big(2));
+    expect(await balances.getBalance(Asset.bitcoin)).toEqual(new Big(1));
+    expect(await balances.getBalance(Asset.ether)).toEqual(new Big(2));
 
     bitcoinBalance = 0;
     etherBalance = 0;
 
-    expect(await balances.getBalance(Asset.Bitcoin)).toEqual(new Big(0));
-    expect(await balances.getBalance(Asset.Ether)).toEqual(new Big(0));
+    expect(await balances.getBalance(Asset.bitcoin)).toEqual(new Big(0));
+    expect(await balances.getBalance(Asset.ether)).toEqual(new Big(0));
   });
 
   it("Should return the original balance after the balance changed", async () => {
@@ -47,18 +47,18 @@ describe("Balances tests", () => {
       lowFundsThresholdPercentage
     );
 
-    expect(await balances.getOriginalBalance(Asset.Bitcoin)).toEqual(
+    expect(await balances.getOriginalBalance(Asset.bitcoin)).toEqual(
       new Big(1)
     );
-    expect(await balances.getOriginalBalance(Asset.Ether)).toEqual(new Big(2));
+    expect(await balances.getOriginalBalance(Asset.ether)).toEqual(new Big(2));
 
     bitcoinBalance = 0;
     etherBalance = 0;
 
-    expect(await balances.getOriginalBalance(Asset.Bitcoin)).toEqual(
+    expect(await balances.getOriginalBalance(Asset.bitcoin)).toEqual(
       new Big(1)
     );
-    expect(await balances.getOriginalBalance(Asset.Ether)).toEqual(new Big(2));
+    expect(await balances.getOriginalBalance(Asset.ether)).toEqual(new Big(2));
   });
 
   it("Should return insufficient funds if funds are 0", async () => {
@@ -70,7 +70,7 @@ describe("Balances tests", () => {
       lowFundsThresholdPercentage
     );
 
-    expect(await balances.isSufficientFunds(Asset.Bitcoin)).toBeFalsy();
+    expect(await balances.isSufficientFunds(Asset.bitcoin)).toBeFalsy();
   });
 
   it("Should return insufficient funds if balance minus trade amount is equal or below 0", async () => {
@@ -83,7 +83,7 @@ describe("Balances tests", () => {
     );
 
     expect(
-      await balances.isSufficientFunds(Asset.Bitcoin, new Big(1.0001))
+      await balances.isSufficientFunds(Asset.bitcoin, new Big(1.0001))
     ).toBeFalsy();
   });
 
@@ -99,10 +99,10 @@ describe("Balances tests", () => {
     );
 
     bitcoinBalance = 1;
-    expect(await balances.isLowBalance(Asset.Bitcoin)).toBeTruthy();
+    expect(await balances.isLowBalance(Asset.bitcoin)).toBeTruthy();
 
     bitcoinBalance = 2;
-    expect(await balances.isLowBalance(Asset.Bitcoin)).toBeTruthy();
+    expect(await balances.isLowBalance(Asset.bitcoin)).toBeTruthy();
   });
 
   it("Should not return low funds if balance is over the threshold", async () => {
@@ -117,6 +117,6 @@ describe("Balances tests", () => {
     );
     bitcoinBalance = 2.1;
 
-    expect(await balances.isLowBalance(Asset.Bitcoin)).toBeFalsy();
+    expect(await balances.isLowBalance(Asset.bitcoin)).toBeFalsy();
   });
 });

--- a/tests/rates/staticRates.spec.ts
+++ b/tests/rates/staticRates.spec.ts
@@ -16,14 +16,15 @@ describe("Rate tests", () => {
       timestamp: new Date(),
       buy: {
         ledger: Ledger.Bitcoin,
-        asset: Asset.Bitcoin,
+        asset: Asset.bitcoin,
         quantity: new Big(0.1)
       },
       sell: {
         ledger: Ledger.Ethereum,
-        asset: Asset.Ether,
+        asset: Asset.ether,
         quantity: new Big(0.0009)
-      }
+      },
+      protocol: "rfc003"
     };
 
     const rates = new StaticRates(config);
@@ -40,14 +41,15 @@ describe("Rate tests", () => {
       timestamp: new Date(),
       buy: {
         ledger: Ledger.Bitcoin,
-        asset: Asset.Bitcoin,
+        asset: Asset.bitcoin,
         quantity: new Big(0.1)
       },
       sell: {
         ledger: Ledger.Ethereum,
-        asset: Asset.Ether,
+        asset: Asset.ether,
         quantity: new Big(0.0011)
-      }
+      },
+      protocol: "rfc003"
     };
 
     const rates = new StaticRates(config);
@@ -58,27 +60,29 @@ describe("Rate tests", () => {
     const trades: List<Trade> = [
       {
         timestamp: new Date(),
+        protocol: "rfc003",
         buy: {
           ledger: Ledger.Bitcoin,
-          asset: Asset.Bitcoin,
+          asset: Asset.bitcoin,
           quantity: new Big(1)
         },
         sell: {
           ledger: Ledger.Ethereum,
-          asset: Asset.Ether,
+          asset: Asset.ether,
           quantity: new Big(100)
         }
       },
       {
         timestamp: new Date(),
+        protocol: "rfc003",
         buy: {
           ledger: Ledger.Ethereum,
-          asset: Asset.Ether,
+          asset: Asset.ether,
           quantity: new Big(1)
         },
         sell: {
           ledger: Ledger.Bitcoin,
-          asset: Asset.Bitcoin,
+          asset: Asset.bitcoin,
           quantity: new Big(0.01)
         }
       }

--- a/tests/rates/testnetMarketMaker.spec.ts
+++ b/tests/rates/testnetMarketMaker.spec.ts
@@ -18,8 +18,8 @@ async function createMockBalances(
 }
 
 describe("Test the TestnetMarketMaker module", () => {
-  const buyAsset = Asset.Bitcoin;
-  const sellAsset = Asset.Ether;
+  const buyAsset = Asset.bitcoin;
+  const sellAsset = Asset.ether;
 
   it("Throws when creating the Market Maker if maxFraction is greater than the publishFraction", async () => {
     const balances = await createMockBalances(1, 1);
@@ -38,14 +38,15 @@ describe("Test the TestnetMarketMaker module", () => {
   it("Returns the amounts to publish for buy and sell assets based on the balances, the configured published fraction and the rate spread", async () => {
     const trade: Trade = {
       timestamp: new Date(),
+      protocol: "rfc003",
       buy: {
         ledger: Ledger.Bitcoin,
-        asset: Asset.Bitcoin,
+        asset: Asset.bitcoin,
         quantity: new Big(0.525)
       },
       sell: {
         ledger: Ledger.Ethereum,
-        asset: Asset.Ether,
+        asset: Asset.ether,
         quantity: new Big(5)
       }
     };
@@ -71,7 +72,7 @@ describe("Test the TestnetMarketMaker module", () => {
       await createMockBalances(100, 0)
     );
     await expect(
-      marketMaker.prepareTradesToPublishForAsset(Asset.Bitcoin, Asset.Ether)
+      marketMaker.prepareTradesToPublishForAsset(Asset.bitcoin, Asset.ether)
     ).rejects.toThrowError(
       "Insufficient funding of asset ether to publish trades"
     );
@@ -83,16 +84,17 @@ describe("Test the TestnetMarketMaker module", () => {
       await createMockBalances(100, 0)
     );
 
-    const trade = {
+    const trade: Trade = {
       timestamp: new Date(),
+      protocol: "rfc003",
       buy: {
         ledger: Ledger.Bitcoin,
-        asset: Asset.Bitcoin,
+        asset: Asset.bitcoin,
         quantity: new Big(0.1)
       },
       sell: {
         ledger: Ledger.Ethereum,
-        asset: Asset.Ether,
+        asset: Asset.ether,
         quantity: new Big(1)
       }
     };
@@ -136,16 +138,17 @@ describe("Test the TestnetMarketMaker module", () => {
       await createMockBalances(100, 1000)
     );
 
-    const trade = {
+    const trade: Trade = {
       timestamp: new Date(),
+      protocol: "rfc003",
       buy: {
         ledger: Ledger.Bitcoin,
-        asset: Asset.Bitcoin,
+        asset: Asset.bitcoin,
         quantity: new Big(1)
       },
       sell: {
         ledger: Ledger.Ethereum,
-        asset: Asset.Ether,
+        asset: Asset.ether,
         quantity: new Big(10)
       }
     };
@@ -159,16 +162,17 @@ describe("Test the TestnetMarketMaker module", () => {
       await createMockBalances(100, 1000)
     );
 
-    const trade = {
+    const trade: Trade = {
       timestamp: new Date(),
+      protocol: "rfc003",
       buy: {
         ledger: Ledger.Bitcoin,
-        asset: Asset.Bitcoin,
+        asset: Asset.bitcoin,
         quantity: new Big(0.1)
       },
       sell: {
         ledger: Ledger.Ethereum,
-        asset: Asset.Ether,
+        asset: Asset.ether,
         quantity: new Big(1.1)
       }
     };
@@ -182,16 +186,17 @@ describe("Test the TestnetMarketMaker module", () => {
       await createMockBalances(100, 1000)
     );
 
-    const trade = {
+    const trade: Trade = {
       timestamp: new Date(),
+      protocol: "rfc003",
       buy: {
         ledger: Ledger.Bitcoin,
-        asset: Asset.Bitcoin,
+        asset: Asset.bitcoin,
         quantity: new Big(10)
       },
       sell: {
         ledger: Ledger.Ethereum,
-        asset: Asset.Ether,
+        asset: Asset.ether,
         quantity: new Big(11) // 10 is the max fraction: 1000/100
       }
     };
@@ -203,27 +208,29 @@ describe("Test the TestnetMarketMaker module", () => {
     const expected: List<Trade> = [
       {
         timestamp: new Date(),
+        protocol: "rfc003",
         buy: {
           ledger: Ledger.Bitcoin,
-          asset: Asset.Bitcoin,
+          asset: Asset.bitcoin,
           quantity: new Big(0.525)
         },
         sell: {
           ledger: Ledger.Ethereum,
-          asset: Asset.Ether,
+          asset: Asset.ether,
           quantity: new Big(5)
         }
       },
       {
         timestamp: new Date(),
+        protocol: "rfc003",
         buy: {
           ledger: Ledger.Ethereum,
-          asset: Asset.Ether,
+          asset: Asset.ether,
           quantity: new Big(5.25)
         },
         sell: {
           ledger: Ledger.Bitcoin,
-          asset: Asset.Bitcoin,
+          asset: Asset.bitcoin,
           quantity: new Big(0.5)
         }
       }

--- a/tests/routes/tradesToPublish.spec.ts
+++ b/tests/routes/tradesToPublish.spec.ts
@@ -5,7 +5,8 @@ import Ledger from "../../src/ledger";
 import { Trade, TradeService } from "../../src/rates/tradeService";
 import {
   findLatestTradeTimestamp,
-  getAmountsToPublishRoute
+  getAmountsToPublishRoute,
+  ToPublish
 } from "../../src/routes/tradesToPublish";
 import EthereumWalletStub from "../doubles/ethereumWalletStub";
 
@@ -18,12 +19,12 @@ const btcEthTrade: Trade = {
   protocol: "rfc003",
   buy: {
     ledger: Ledger.Bitcoin,
-    asset: Asset.Bitcoin,
+    asset: Asset.bitcoin,
     quantity: new Big(1)
   },
   sell: {
     ledger: Ledger.Ethereum,
-    asset: Asset.Ether,
+    asset: Asset.ether,
     quantity: new Big(100)
   }
 };
@@ -33,12 +34,12 @@ const ethBtcTrade: Trade = {
   protocol: "rfc003",
   buy: {
     ledger: Ledger.Ethereum,
-    asset: Asset.Ether,
+    asset: Asset.ether,
     quantity: new Big(80)
   },
   sell: {
     ledger: Ledger.Bitcoin,
-    asset: Asset.Bitcoin,
+    asset: Asset.bitcoin,
     quantity: new Big(1)
   }
 };
@@ -114,7 +115,7 @@ describe("TradesToPublish tests ", () => {
 
       sell: {
         ledger: Ledger.Ethereum,
-        asset: Asset.Ether,
+        asset: Asset.ether,
         quantity: new Big(110)
       }
     };
@@ -136,7 +137,7 @@ describe("TradesToPublish tests ", () => {
       timestamp: past,
       sell: {
         ledger: Ledger.Ethereum,
-        asset: Asset.Ether,
+        asset: Asset.ether,
         quantity: new Big(110)
       }
     };
@@ -198,7 +199,7 @@ describe("TradesToPublish tests ", () => {
       }
     };
 
-    const expected = {
+    const expected: ToPublish = {
       peerId: "somePeerId",
       addressHint: "/ip4/127.0.0.1/tcp/8011",
       ledgers: [


### PR DESCRIPTION
Make the enum `Asset` a class to prepare for the need of attributes when the asset is an ERC-20.

Also remove some TS warnings/ignore.

Helps #21.