### PR TITLE
Erc20 - testnet market maker

### DIFF
--- a/src/asset.ts
+++ b/src/asset.ts
@@ -81,6 +81,10 @@ class Asset {
     }
   }
 
+  public toMapKey(): string {
+    return JSON.stringify(this);
+  }
+
   private toNominalUnitForToken(quantity: Big) {
     if (this.decimals) {
       return quantity.div(new Big(10).pow(this.decimals));

--- a/src/index.ts
+++ b/src/index.ts
@@ -234,9 +234,9 @@ const config = Config.fromFile(CONFIG_PATH);
 
   if (config.apiPort) {
     api.listen(config.apiPort, () =>
-      console.log(`API exposed at port ${config.apiPort}`)
+      logger.info(`API exposed at port ${config.apiPort}`)
     );
   } else {
-    console.warn("API port not configured - not exposing API");
+    logger.info("API port not configured - not exposing API");
   }
 })();

--- a/src/index.ts
+++ b/src/index.ts
@@ -103,12 +103,15 @@ const config = Config.fromFile(CONFIG_PATH);
   } = await initBitcoin(config);
   const ethereumParams = await initEthereum(config);
 
+  const tokens = Tokens.fromFile(TOKENS_CONFIG_PATH);
+
   const tradeService = await createTradeEvaluationService({
     testnetMarketMaker: config.testnetMarketMaker,
     staticRates: config.staticRates,
     lowBalanceThresholdPercentage: config.lowBalanceThresholdPercentage,
     ethereumWallet: ethereumParams.ethereumWallet,
-    bitcoinWallet
+    bitcoinWallet,
+    tokens
   });
 
   let bitcoinLedgerExecutorParams;
@@ -147,7 +150,6 @@ const config = Config.fromFile(CONFIG_PATH);
     bitcoinLedgerExecutorParams,
     ethereumLedgerExecutorParams
   );
-  const tokens = Tokens.fromFile(TOKENS_CONFIG_PATH);
   let createAssetFromTokens;
   if (tokens) {
     createAssetFromTokens = tokens.createAsset;

--- a/src/rates/balances.ts
+++ b/src/rates/balances.ts
@@ -4,41 +4,25 @@ import Asset from "../asset";
 export type BalanceLookups = Map<Asset, () => Promise<Big>>;
 
 export default class Balances {
-  public static async create(
-    balanceLookups: BalanceLookups,
-    lowFundsThresholdPercentage: number
-  ): Promise<Balances> {
-    const balances = new Balances(lowFundsThresholdPercentage);
-
-    const promises: Array<Promise<void>> = [];
-    balanceLookups.forEach((value: () => Promise<Big>, asset: Asset) => {
-      promises.push(
-        (async (value, asset) => {
-          if (!asset) {
-            throw new Error(`Asset ${asset} not supported`);
-          }
-          balances.balanceLookup.set(asset.toMapKey(), value);
-          const originalBalance = await value();
-          balances.originalBalance.set(asset.toMapKey(), originalBalance);
-        })(value, asset)
-      );
-    });
-
-    await Promise.all(promises);
-    return balances;
-  }
-
   private balanceLookup: Map<string, () => Promise<Big>>;
   private originalBalance: Map<string, Big>;
   private readonly lowFundsThresholdPercentage: Big;
 
-  private constructor(lowFundsThresholdPercentage: number) {
+  public constructor(lowFundsThresholdPercentage: number) {
     this.lowFundsThresholdPercentage = new Big(lowFundsThresholdPercentage).div(
       100
     );
 
     this.balanceLookup = new Map<string, () => Promise<Big>>();
     this.originalBalance = new Map<string, Big>();
+  }
+  public async addBalanceLookup(
+    asset: Asset,
+    balanceLookup: () => Promise<Big>
+  ): Promise<void> {
+    this.balanceLookup.set(asset.toMapKey(), balanceLookup);
+    const originalBalance = await balanceLookup();
+    this.originalBalance.set(asset.toMapKey(), originalBalance);
   }
 
   public getBalance(asset: Asset): Promise<Big> {

--- a/src/rates/tradeService.ts
+++ b/src/rates/tradeService.ts
@@ -2,6 +2,7 @@ import Big from "big.js";
 import Asset from "../asset";
 import Ledger from "../ledger";
 import { getLogger } from "../logging/logger";
+import Tokens from "../tokens";
 import { BitcoinWallet } from "../wallets/bitcoin";
 import { EthereumWallet } from "../wallets/ethereum";
 import Balances from "./balances";
@@ -36,6 +37,7 @@ export interface InitialiseRateParameters {
   lowBalanceThresholdPercentage?: number;
   ethereumWallet?: EthereumWallet;
   bitcoinWallet?: BitcoinWallet;
+  tokens?: Tokens;
 }
 
 export async function createTradeEvaluationService({
@@ -43,7 +45,8 @@ export async function createTradeEvaluationService({
   staticRates,
   lowBalanceThresholdPercentage,
   ethereumWallet,
-  bitcoinWallet
+  bitcoinWallet,
+  tokens
 }: InitialiseRateParameters) {
   const testnetMarketMakerConfig = testnetMarketMaker;
   const staticRatesConfig = staticRates;
@@ -93,7 +96,13 @@ export async function createTradeEvaluationService({
       lowBalanceThresholdPercentage
     );
 
-    return new TestnetMarketMaker(testnetMarketMakerConfig, balances);
+    const getTokens = tokens ? tokens.getAssets.bind(tokens) : () => [];
+
+    return new TestnetMarketMaker(
+      testnetMarketMakerConfig,
+      balances,
+      getTokens
+    );
   } else {
     throw new Error("No rate strategy defined.");
   }

--- a/src/rates/tradeService.ts
+++ b/src/rates/tradeService.ts
@@ -87,14 +87,10 @@ export async function createTradeEvaluationService({
       return Promise.resolve(new Big(0));
     };
 
-    const balanceLookups = new Map();
-    balanceLookups.set(Asset.bitcoin, bitcoinBalanceLookup);
-    balanceLookups.set(Asset.ether, etherBalanceLookup);
+    const balances = new Balances(lowBalanceThresholdPercentage);
 
-    const balances = await Balances.create(
-      balanceLookups,
-      lowBalanceThresholdPercentage
-    );
+    await balances.addBalanceLookup(Asset.bitcoin, bitcoinBalanceLookup);
+    await balances.addBalanceLookup(Asset.ether, etherBalanceLookup);
 
     const getTokens = tokens ? tokens.getAssets.bind(tokens) : () => [];
 

--- a/src/rates/tradeService.ts
+++ b/src/rates/tradeService.ts
@@ -96,6 +96,24 @@ export async function createTradeEvaluationService({
       ? (ledger: Ledger) => tokens.getAssets(ledger)
       : () => [];
 
+    if (tokens) {
+      const ethTokens = tokens.getAssets(Ledger.Ethereum);
+
+      ethTokens.map(async token => {
+        const balanceLookup = async () => {
+          if (ethereumWallet) {
+            try {
+              return ethereumWallet.getBalance(token);
+            } catch (e) {
+              logger.crit("balance not found for ", token, e);
+            }
+          }
+          return Promise.resolve(new Big(0));
+        };
+        await balances.addBalanceLookup(token, balanceLookup);
+      });
+    }
+
     return new TestnetMarketMaker(
       testnetMarketMakerConfig,
       balances,

--- a/src/rates/tradeService.ts
+++ b/src/rates/tradeService.ts
@@ -84,10 +84,9 @@ export async function createTradeEvaluationService({
       return Promise.resolve(new Big(0));
     };
 
-    const balanceLookups = {
-      bitcoin: bitcoinBalanceLookup,
-      ether: etherBalanceLookup
-    };
+    const balanceLookups = new Map();
+    balanceLookups.set(Asset.bitcoin, bitcoinBalanceLookup);
+    balanceLookups.set(Asset.ether, etherBalanceLookup);
 
     const balances = await Balances.create(
       balanceLookups,

--- a/src/rates/tradeService.ts
+++ b/src/rates/tradeService.ts
@@ -92,7 +92,9 @@ export async function createTradeEvaluationService({
     await balances.addBalanceLookup(Asset.bitcoin, bitcoinBalanceLookup);
     await balances.addBalanceLookup(Asset.ether, etherBalanceLookup);
 
-    const getTokens = tokens ? tokens.getAssets.bind(tokens) : () => [];
+    const getTokens = tokens
+      ? (ledger: Ledger) => tokens.getAssets(ledger)
+      : () => [];
 
     return new TestnetMarketMaker(
       testnetMarketMakerConfig,

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -74,4 +74,8 @@ export default class Tokens {
 
     return this.ethereumTokens.get(contractAddress);
   }
+
+  public getAssets(): Asset[] {
+    throw new Error("Not implemented");
+  }
 }

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -75,8 +75,8 @@ export default class Tokens {
     return this.ethereumTokens.get(contractAddress);
   }
 
-  public getAssets(): Asset[] {
-    if (this.ethereumTokens) {
+  public getAssets(ledger: Ledger): Asset[] {
+    if (ledger === Ledger.Ethereum && this.ethereumTokens) {
       return Array.from(this.ethereumTokens.values());
     }
     return [];

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -76,6 +76,9 @@ export default class Tokens {
   }
 
   public getAssets(): Asset[] {
-    throw new Error("Not implemented");
+    if (this.ethereumTokens) {
+      return Array.from(this.ethereumTokens.values());
+    }
+    return [];
   }
 }

--- a/tests/rates/balances.spec.ts
+++ b/tests/rates/balances.spec.ts
@@ -17,14 +17,11 @@ describe("Balances tests", () => {
     let bitcoinBalance = 1;
     let etherBalance = 2;
 
-    const balanceLookups = new Map();
-    balanceLookups.set(Asset.bitcoin, () => balance(bitcoinBalance));
-    balanceLookups.set(Asset.ether, () => balance(etherBalance));
-
-    const balances = await Balances.create(
-      balanceLookups,
-      lowFundsThresholdPercentage
+    const balances = new Balances(lowFundsThresholdPercentage);
+    await balances.addBalanceLookup(Asset.bitcoin, () =>
+      balance(bitcoinBalance)
     );
+    await balances.addBalanceLookup(Asset.ether, () => balance(etherBalance));
 
     expect(await balances.getBalance(Asset.bitcoin)).toEqual(new Big(1));
     expect(await balances.getBalance(Asset.ether)).toEqual(new Big(2));
@@ -40,13 +37,11 @@ describe("Balances tests", () => {
     let bitcoinBalance = 1;
     let etherBalance = 2;
 
-    const balanceLookups = new Map();
-    balanceLookups.set(Asset.bitcoin, () => balance(bitcoinBalance));
-    balanceLookups.set(Asset.ether, () => balance(etherBalance));
-    const balances = await Balances.create(
-      balanceLookups,
-      lowFundsThresholdPercentage
+    const balances = new Balances(lowFundsThresholdPercentage);
+    await balances.addBalanceLookup(Asset.bitcoin, () =>
+      balance(bitcoinBalance)
     );
+    await balances.addBalanceLookup(Asset.ether, () => balance(etherBalance));
 
     expect(await balances.getOriginalBalance(Asset.bitcoin)).toEqual(
       new Big(1)
@@ -63,25 +58,17 @@ describe("Balances tests", () => {
   });
 
   it("Should return insufficient funds if funds are 0", async () => {
-    const balanceLookups = new Map();
-    balanceLookups.set(Asset.bitcoin, () => balance(0));
-    balanceLookups.set(Asset.ether, () => balance(0));
-    const balances = await Balances.create(
-      balanceLookups,
-      lowFundsThresholdPercentage
-    );
+    const balances = new Balances(lowFundsThresholdPercentage);
+    await balances.addBalanceLookup(Asset.bitcoin, () => balance(0));
+    await balances.addBalanceLookup(Asset.ether, () => balance(0));
 
     expect(await balances.isSufficientFunds(Asset.bitcoin)).toBeFalsy();
   });
 
   it("Should return insufficient funds if balance minus trade amount is equal or below 0", async () => {
-    const balanceLookups = new Map();
-    balanceLookups.set(Asset.bitcoin, () => balance(1));
-    balanceLookups.set(Asset.ether, () => balance(0));
-    const balances = await Balances.create(
-      balanceLookups,
-      lowFundsThresholdPercentage
-    );
+    const balances = new Balances(lowFundsThresholdPercentage);
+    await balances.addBalanceLookup(Asset.bitcoin, () => balance(1));
+    await balances.addBalanceLookup(Asset.ether, () => balance(0));
 
     expect(
       await balances.isSufficientFunds(Asset.bitcoin, new Big(1.0001))
@@ -90,13 +77,11 @@ describe("Balances tests", () => {
 
   it("Should return low funds if balance is below the threshold", async () => {
     let bitcoinBalance = 10;
-    const balanceLookups = new Map();
-    balanceLookups.set(Asset.bitcoin, () => balance(bitcoinBalance));
-    balanceLookups.set(Asset.ether, () => balance(0));
-    const balances = await Balances.create(
-      balanceLookups,
-      lowFundsThresholdPercentage
+    const balances = new Balances(lowFundsThresholdPercentage);
+    await balances.addBalanceLookup(Asset.bitcoin, () =>
+      balance(bitcoinBalance)
     );
+    await balances.addBalanceLookup(Asset.ether, () => balance(0));
 
     bitcoinBalance = 1;
     expect(await balances.isLowBalance(Asset.bitcoin)).toBeTruthy();
@@ -108,13 +93,11 @@ describe("Balances tests", () => {
   it("Should not return low funds if balance is over the threshold", async () => {
     let bitcoinBalance = 10;
 
-    const balanceLookups = new Map();
-    balanceLookups.set(Asset.bitcoin, () => balance(bitcoinBalance));
-    balanceLookups.set(Asset.ether, () => balance(0));
-    const balances = await Balances.create(
-      balanceLookups,
-      lowFundsThresholdPercentage
+    const balances = new Balances(lowFundsThresholdPercentage);
+    await balances.addBalanceLookup(Asset.bitcoin, () =>
+      balance(bitcoinBalance)
     );
+    await balances.addBalanceLookup(Asset.ether, () => balance(0));
     bitcoinBalance = 2.1;
 
     expect(await balances.isLowBalance(Asset.bitcoin)).toBeFalsy();

--- a/tests/rates/balances.spec.ts
+++ b/tests/rates/balances.spec.ts
@@ -17,11 +17,12 @@ describe("Balances tests", () => {
     let bitcoinBalance = 1;
     let etherBalance = 2;
 
+    const balanceLookups = new Map();
+    balanceLookups.set(Asset.bitcoin, () => balance(bitcoinBalance));
+    balanceLookups.set(Asset.ether, () => balance(etherBalance));
+
     const balances = await Balances.create(
-      {
-        bitcoin: () => balance(bitcoinBalance),
-        ether: () => balance(etherBalance)
-      },
+      balanceLookups,
       lowFundsThresholdPercentage
     );
 
@@ -39,11 +40,11 @@ describe("Balances tests", () => {
     let bitcoinBalance = 1;
     let etherBalance = 2;
 
+    const balanceLookups = new Map();
+    balanceLookups.set(Asset.bitcoin, () => balance(bitcoinBalance));
+    balanceLookups.set(Asset.ether, () => balance(etherBalance));
     const balances = await Balances.create(
-      {
-        bitcoin: () => balance(bitcoinBalance),
-        ether: () => balance(etherBalance)
-      },
+      balanceLookups,
       lowFundsThresholdPercentage
     );
 
@@ -62,11 +63,11 @@ describe("Balances tests", () => {
   });
 
   it("Should return insufficient funds if funds are 0", async () => {
+    const balanceLookups = new Map();
+    balanceLookups.set(Asset.bitcoin, () => balance(0));
+    balanceLookups.set(Asset.ether, () => balance(0));
     const balances = await Balances.create(
-      {
-        bitcoin: () => balance(0),
-        ether: () => balance(0)
-      },
+      balanceLookups,
       lowFundsThresholdPercentage
     );
 
@@ -74,11 +75,11 @@ describe("Balances tests", () => {
   });
 
   it("Should return insufficient funds if balance minus trade amount is equal or below 0", async () => {
+    const balanceLookups = new Map();
+    balanceLookups.set(Asset.bitcoin, () => balance(1));
+    balanceLookups.set(Asset.ether, () => balance(0));
     const balances = await Balances.create(
-      {
-        bitcoin: () => balance(1),
-        ether: () => balance(0)
-      },
+      balanceLookups,
       lowFundsThresholdPercentage
     );
 
@@ -89,12 +90,11 @@ describe("Balances tests", () => {
 
   it("Should return low funds if balance is below the threshold", async () => {
     let bitcoinBalance = 10;
-
+    const balanceLookups = new Map();
+    balanceLookups.set(Asset.bitcoin, () => balance(bitcoinBalance));
+    balanceLookups.set(Asset.ether, () => balance(0));
     const balances = await Balances.create(
-      {
-        bitcoin: () => balance(bitcoinBalance),
-        ether: () => balance(0)
-      },
+      balanceLookups,
       lowFundsThresholdPercentage
     );
 
@@ -108,11 +108,11 @@ describe("Balances tests", () => {
   it("Should not return low funds if balance is over the threshold", async () => {
     let bitcoinBalance = 10;
 
+    const balanceLookups = new Map();
+    balanceLookups.set(Asset.bitcoin, () => balance(bitcoinBalance));
+    balanceLookups.set(Asset.ether, () => balance(0));
     const balances = await Balances.create(
-      {
-        bitcoin: () => balance(bitcoinBalance),
-        ether: () => balance(0)
-      },
+      balanceLookups,
       lowFundsThresholdPercentage
     );
     bitcoinBalance = 2.1;

--- a/tests/rates/testnetMarketMaker.spec.ts
+++ b/tests/rates/testnetMarketMaker.spec.ts
@@ -12,14 +12,15 @@ async function createMockBalances(
   etherBalance: number,
   payBalance?: number
 ) {
-  const mockBalanceLookups = new Map();
-  mockBalanceLookups.set(Asset.bitcoin, () =>
+  const balances = new Balances(20);
+
+  await balances.addBalanceLookup(Asset.bitcoin, () =>
     Promise.resolve(new Big(bitcoinBalance))
   );
-  mockBalanceLookups.set(Asset.ether, () =>
+
+  await balances.addBalanceLookup(Asset.ether, () =>
     Promise.resolve(new Big(etherBalance))
   );
-
   if (payBalance) {
     const payAsset = new Asset(
       "PAY",
@@ -27,12 +28,11 @@ async function createMockBalances(
       "0xB97048628DB6B661D4C2aA833e95Dbe1A905B280",
       18
     );
-    mockBalanceLookups.set(payAsset, () =>
+    await balances.addBalanceLookup(payAsset, () =>
       Promise.resolve(new Big(payBalance))
     );
   }
-
-  return Balances.create(mockBalanceLookups, 20);
+  return balances;
 }
 
 const payAsset = new Asset(

--- a/tests/rates/testnetMarketMaker.spec.ts
+++ b/tests/rates/testnetMarketMaker.spec.ts
@@ -34,6 +34,13 @@ async function createMockBalances(
   return Balances.create(mockBalanceLookups, 20);
 }
 
+const payAsset = new Asset(
+  "PAY",
+  Ledger.Ethereum,
+  "0xB97048628DB6B661D4C2aA833e95Dbe1A905B280",
+  18
+);
+
 describe("Test the TestnetMarketMaker module", () => {
   const buyAsset = Asset.bitcoin;
   const sellAsset = Asset.ether;
@@ -265,12 +272,6 @@ describe("Test the TestnetMarketMaker module", () => {
   });
 
   it("Returns the amounts to publish for buy and sell assets with an ERC20 asset based on the balances, the configured published fraction and the rate spread", async () => {
-    const payAsset = new Asset(
-      "PAY",
-      Ledger.Ethereum,
-      "0xB97048628DB6B661D4C2aA833e95Dbe1A905B280",
-      18
-    );
     const offer: Offer = {
       timestamp: new Date(),
       protocol: "rfc003",
@@ -298,5 +299,66 @@ describe("Test the TestnetMarketMaker module", () => {
     expect(offersToPublish).toBeDefined();
     expect(offersToPublish.buy).toEqual(offer.buy); // Based on the publish fraction
     expect(offersToPublish.sell).toEqual(offer.sell);
+  });
+
+  it("Should return the trades, including ERC20, according to the balance", async () => {
+    const expected: List<Offer> = [
+      {
+        timestamp: new Date(),
+        protocol: "rfc003",
+        buy: {
+          ledger: Ledger.Bitcoin,
+          asset: Asset.bitcoin,
+          quantity: new Big(0.525)
+        },
+        sell: {
+          ledger: Ledger.Ethereum,
+          asset: Asset.ether,
+          quantity: new Big(5)
+        }
+      },
+      {
+        timestamp: new Date(),
+        protocol: "rfc003",
+        buy: {
+          ledger: Ledger.Ethereum,
+          asset: Asset.ether,
+          quantity: new Big(5.25)
+        },
+        sell: {
+          ledger: Ledger.Bitcoin,
+          asset: Asset.bitcoin,
+          quantity: new Big(0.5)
+        }
+      },
+      {
+        timestamp: new Date(),
+        protocol: "rfc003",
+        buy: {
+          ledger: Ledger.Ethereum,
+          asset: payAsset,
+          quantity: new Big(5.25)
+        },
+        sell: {
+          ledger: Ledger.Bitcoin,
+          asset: Asset.bitcoin,
+          quantity: new Big(0.5)
+        }
+      }
+    ];
+
+    const marketMaker = new TestnetMarketMaker(
+      { rateSpread: 5, publishFraction: 200, maxFraction: 100 },
+      await createMockBalances(100, 1000, 10000)
+    );
+
+    const trades = await marketMaker.prepareOffersToPublish();
+
+    expect(trades[0].buy).toEqual(expected[0].buy);
+    expect(trades[0].sell).toEqual(expected[0].sell);
+    expect(trades[1].buy).toEqual(expected[1].buy);
+    expect(trades[1].sell).toEqual(expected[1].sell);
+    expect(trades[2].buy).toEqual(expected[2].buy);
+    expect(trades[2].sell).toEqual(expected[2].sell);
   });
 });

--- a/tests/rates/tradeService.spec.ts
+++ b/tests/rates/tradeService.spec.ts
@@ -13,7 +13,7 @@ describe("Test TradeService module", () => {
   });
 
   it("should load the static rate if passed", async () => {
-    const rates = createTradeEvaluationService({
+    const rates = await createTradeEvaluationService({
       staticRates: { ether: { bitcoin: 0.0105 }, bitcoin: { ether: 105.26 } },
       bitcoinWallet,
       ethereumWallet
@@ -23,7 +23,7 @@ describe("Test TradeService module", () => {
   });
 
   it("should set the marketmaker if no rates is passed", async () => {
-    const rates = createTradeEvaluationService({
+    const rates = await createTradeEvaluationService({
       testnetMarketMaker: {
         rateSpread: 5,
         maxFraction: 1000,

--- a/tests/routes/tradesToPublish.spec.ts
+++ b/tests/routes/tradesToPublish.spec.ts
@@ -14,6 +14,12 @@ const present = new Date();
 const past = new Date(present.getTime() - 5000);
 const future = new Date(present.getTime() + 5000);
 
+const payAsset = new Asset(
+  "PAY",
+  Ledger.Ethereum,
+  "0xB97048628DB6B661D4C2aA833e95Dbe1A905B280"
+);
+
 const btcEthTrade: Offer = {
   timestamp: present,
   protocol: "rfc003",
@@ -41,6 +47,21 @@ const ethBtcTrade: Offer = {
     ledger: Ledger.Bitcoin,
     asset: Asset.bitcoin,
     quantity: new Big(1)
+  }
+};
+
+const btcPayTrade: Offer = {
+  timestamp: present,
+  protocol: "rfc003",
+  buy: {
+    ledger: Ledger.Bitcoin,
+    asset: Asset.bitcoin,
+    quantity: new Big(1)
+  },
+  sell: {
+    ledger: Ledger.Ethereum,
+    asset: payAsset,
+    quantity: new Big(1000)
   }
 };
 
@@ -166,7 +187,7 @@ describe("TradesToPublish tests ", () => {
   });
 
   class MockMarketMaker implements TradeService {
-    protected trades: Offer[] = [ethBtcTrade, btcEthTrade];
+    protected trades: Offer[] = [ethBtcTrade, btcEthTrade, btcPayTrade];
 
     public isOfferAcceptable(_: Offer): Promise<boolean> {
       return Promise.resolve(true);
@@ -240,17 +261,31 @@ describe("TradesToPublish tests ", () => {
             quantity: "100"
           },
           timestamp: btcEthTrade.timestamp.toISOString()
+        },
+        {
+          buy: {
+            asset: "bitcoin",
+            ledger: "bitcoin",
+            quantity: "1"
+          },
+          protocol: "rfc003",
+          sell: {
+            asset: "PAY",
+            ledger: "ethereum",
+            quantity: "1000"
+          },
+          timestamp: btcPayTrade.timestamp.toISOString()
         }
       ]
     };
 
     await apiCall(req as any, res as any);
-    let result = await res.sendCalledWith;
+    let result = res.sendCalledWith;
     expect(result).toBeDefined();
     expect(result).toEqual(expected);
 
     await apiCall(req as any, res as any);
-    result = await res.sendCalledWith;
+    result = res.sendCalledWith;
     expect(result).toBeDefined();
     expect(result).toEqual(expected);
   });

--- a/tests/tokens.spec.ts
+++ b/tests/tokens.spec.ts
@@ -104,7 +104,7 @@ describe("Test Tokens", () => {
       18
     );
 
-    const assets = tokens.getAssets();
+    const assets = tokens.getAssets(Ledger.Ethereum);
 
     expect(
       isEqual(tenxAsset, assets[0]) || isEqual(payAsset, assets[0])

--- a/tests/tokens.spec.ts
+++ b/tests/tokens.spec.ts
@@ -1,3 +1,4 @@
+import { isEqual } from "underscore";
 import Asset from "../src/asset";
 import Ledger from "../src/ledger";
 import Tokens, { TokensConfig } from "../src/tokens";
@@ -105,7 +106,11 @@ describe("Test Tokens", () => {
 
     const assets = tokens.getAssets();
 
-    expect(assets).toContain(payAsset);
-    expect(assets).toContain(tenxAsset);
+    expect(
+      isEqual(tenxAsset, assets[0]) || isEqual(payAsset, assets[0])
+    ).toBeTruthy();
+    expect(
+      isEqual(tenxAsset, assets[1]) || isEqual(payAsset, assets[1])
+    ).toBeTruthy();
   });
 });

--- a/tests/tokens.spec.ts
+++ b/tests/tokens.spec.ts
@@ -87,4 +87,25 @@ describe("Test Tokens", () => {
     const tokens = Tokens.fromFile("./tests/configs/doesNotExists.toml");
     expect(tokens).toBeUndefined();
   });
+
+  it("Returns all configured tokens", () => {
+    const tokens = new Tokens(tokensConfig);
+    const payAsset = new Asset(
+      "PAY",
+      Ledger.Ethereum,
+      "0xB97048628DB6B661D4C2aA833e95Dbe1A905B280",
+      18
+    );
+    const tenxAsset = new Asset(
+      "TENX",
+      Ledger.Ethereum,
+      "0x515bA0a2E286AF10115284F151cF398688A69170",
+      18
+    );
+
+    const assets = tokens.getAssets();
+
+    expect(assets).toContain(payAsset);
+    expect(assets).toContain(tenxAsset);
+  });
 });


### PR DESCRIPTION
Enable Testnet market maker to return ERC20 offers.

Note: For now only the `Asset.name` is returned (ie, "PAY" without contract details).

I will sort out/break the REST API in a new PR.

Work towards #21.