### PR TITLE
Increase default timeout to 60 seconds

### DIFF
--- a/src/bitcoin/bitcoinCoreRpc.ts
+++ b/src/bitcoin/bitcoinCoreRpc.ts
@@ -68,7 +68,8 @@ export class BitcoinCoreRpc implements BitcoinBlockchain {
       username,
       password,
       host,
-      port
+      port,
+      timeout: 60000
     });
   }
 


### PR DESCRIPTION
This PR increases the default timeout of the bitcoind rpc client to 60 seconds. I opted for no config file to keep the configuration overhead to a minimum. 

Resolves #84 