### PR TITLE
Loglevel fix

### DIFF
--- a/src/actionExecutor.ts
+++ b/src/actionExecutor.ts
@@ -37,7 +37,7 @@ export class ActionExecutor {
     let result: Result<any, Error>;
 
     const triggerResult = await this.triggerRequestFromAction(action);
-    logger.log("trace", `Response from action`, triggerResult);
+    logger.debug(`Response from action`, triggerResult);
     result = triggerResult;
     // If the response has a type and payload then a ledger action is needed
     if (triggerResult.isOk) {
@@ -73,7 +73,7 @@ export class ActionExecutor {
     }
 
     if (action.method === "POST" && action.type !== "application/json") {
-      logger.crit("Only 'application/json' action type is supported.");
+      logger.error("Only 'application/json' action type is supported.");
       throw new Error("Only 'application/json' action type is supported.");
     }
     try {

--- a/src/actionSelector.ts
+++ b/src/actionSelector.ts
@@ -42,7 +42,7 @@ export class ActionSelector {
 
       return this.selectSwapAction(swap);
     }
-    logger.crit(`The given entity is not a swap entity`, entity);
+    logger.error(`The given entity is not a swap entity`, entity);
     return undefined;
   }
 
@@ -82,7 +82,7 @@ export class ActionSelector {
         this.selectedActions.push(declineAction);
         return declineAction;
       } else {
-        logger.crit("Decline action is unavailable");
+        logger.error("Decline action is unavailable");
       }
     } else if (refundAction) {
       // Only refund action available, doing nothing for now
@@ -96,7 +96,7 @@ export class ActionSelector {
     const alphaLedger = toLedger(swap.properties.parameters.alpha_ledger.name);
     const betaLedger = toLedger(swap.properties.parameters.beta_ledger.name);
     if (!alphaLedger || !betaLedger) {
-      logger.crit("Ledger is not supported");
+      logger.error("Ledger is not supported");
       return Promise.resolve(false);
     }
     const alphaAsset = Asset.fromComitPayload(
@@ -110,7 +110,7 @@ export class ActionSelector {
       this.createAssetFromTokens
     );
     if (!alphaAsset || !betaAsset) {
-      logger.crit("Asset is not supported");
+      logger.error("Asset is not supported");
       return Promise.resolve(false);
     }
     if (

--- a/src/asset.ts
+++ b/src/asset.ts
@@ -20,7 +20,7 @@ class Asset {
       case Asset.ether.name:
         return Asset.ether;
       default:
-        logger.crit(`Asset not supported: ${name}`);
+        logger.error(`Asset not supported: ${name}`);
         return undefined;
     }
   }
@@ -46,7 +46,7 @@ class Asset {
         if (createAssetFromTokens && ledger && asset.token_contract) {
           return createAssetFromTokens(ledger, asset.token_contract);
         }
-        logger.crit(`Asset not supported`, asset);
+        logger.error(`Asset not supported`, asset);
         return undefined;
     }
   }
@@ -87,7 +87,7 @@ class Asset {
     if (this.contract) {
       return quantity.div(new Big(10).pow(this.contract.decimals));
     }
-    logger.crit("Unit conversion not supported for", this);
+    logger.error("Unit conversion not supported for", this);
     return undefined;
   }
 }

--- a/src/bitcoin/bitcoinCoreRpc.ts
+++ b/src/bitcoin/bitcoinCoreRpc.ts
@@ -104,7 +104,7 @@ export class BitcoinCoreRpc implements BitcoinBlockchain {
       scanobjects
     );
     if (!result || !result.success || result.unspents === undefined) {
-      logger.crit(`Transaction scan failed: `, result);
+      logger.error(`Transaction scan failed: `, result);
       throw new Error(`Transaction scan failed: ${result}`);
     }
     const promises = result.unspents.map(async (res: RpcUtxo) => {
@@ -126,14 +126,14 @@ export class BitcoinCoreRpc implements BitcoinBlockchain {
   ): Promise<string> {
     const txHex = await this.bitcoinClient.getRawTransaction(txId);
     if (typeof txHex !== "string") {
-      logger.crit(`Error retrieving transaction hex: ${txId}`);
+      logger.error(`Error retrieving transaction hex: ${txId}`);
       throw new Error(`Error retrieving transaction hex: ${txId}`);
     }
     const transaction: RpcTransaction = await this.bitcoinClient.decodeRawTransaction(
       txHex
     );
     if (typeof transaction !== "object") {
-      logger.crit(`Error decoding transaction: ${txId}`);
+      logger.error(`Error decoding transaction: ${txId}`);
       throw new Error(`Error decoding transaction: ${txId}`);
     }
 

--- a/src/comitNode.ts
+++ b/src/comitNode.ts
@@ -120,8 +120,7 @@ export class ComitNode {
       };
     }
 
-    logger.log(
-      "trace",
+    logger.debug(
       `Doing a ${options.method} request to ${options.uri}`,
       options
     );

--- a/src/config.ts
+++ b/src/config.ts
@@ -146,7 +146,7 @@ export class Config {
           }
           break;
         default:
-          logger.crit(`Internal error: invalid ledger`, ledger);
+          logger.error(`Internal error: invalid ledger`, ledger);
       }
     }
 
@@ -175,7 +175,7 @@ function throwIfAbsent<T, K extends keyof T>(obj: T, prop: K): T[K] {
   const child = obj[prop];
 
   if (!child) {
-    logger.crit(`Property must be present in the config file`, prop);
+    logger.error(`Property must be present in the config file`, prop);
     throw new Error(`${prop} must be present in the config file`);
   }
 

--- a/src/fieldDataSource.ts
+++ b/src/fieldDataSource.ts
@@ -28,7 +28,7 @@ export class DefaultFieldDataSource {
   }
 
   public async getData(field: Field) {
-    logger.log("trace", `Trying to find data for field`, field);
+    logger.debug(`Trying to find data for field`, field);
     if (
       this.ethereumWallet &&
       field.class.includes("ethereum") &&

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,7 @@ const refreshUtxos = async (bitcoinWallet: InternalBitcoinWallet) => {
   try {
     await bitcoinWallet.refreshUtxo();
   } catch (e) {
-    logger.crit("Failed to refresh UTXO: ", e);
+    logger.error("Failed to refresh UTXO: ", e);
   }
 };
 
@@ -191,14 +191,14 @@ const config = Config.fromFile(CONFIG_PATH);
 
   const shoot = async () => {
     const swaps = await comitNode.getSwaps();
-    logger.log("trace", `Found ${swaps.length} swap(s)`);
+    logger.debug(`Found ${swaps.length} swap(s)`);
 
     for (const swap of swaps) {
       const id = swap.properties ? swap.properties.id : undefined;
       try {
         const selectedAction = await actionSelector.selectActions(swap);
         if (selectedAction) {
-          logger.log("trace", `Selected action for swap ${id}`, selectedAction);
+          logger.debug(`Selected action for swap ${id}`, selectedAction);
           const executionResult = await actionExecutor.execute(
             selectedAction,
             config.maxRetries
@@ -209,10 +209,10 @@ const config = Config.fromFile(CONFIG_PATH);
             executionResult
           );
         } else {
-          logger.log("trace", `No action returned for swap ${id}`);
+          logger.debug(`No action returned for swap ${id}`);
         }
       } catch (err) {
-        logger.crit(`Error has occurred for swap ${id}`, err);
+        logger.error(`Error has occurred for swap ${id}`, err);
       }
     }
   };

--- a/src/index.ts
+++ b/src/index.ts
@@ -87,7 +87,7 @@ const initEthereum = async (config: Config) => {
     config.ethereumConfig.fee.defaultFee,
     config.ethereumConfig.fee.strategy
   );
-  console.log(
+  logger.info(
     `Please fund bobtimus eth account: ${ethereumWallet.getAddress()}`
   );
   return { ethereumWallet, ethereumFeeService };
@@ -203,8 +203,7 @@ const config = Config.fromFile(CONFIG_PATH);
             selectedAction,
             config.maxRetries
           );
-          logger.log(
-            "trace",
+          logger.debug(
             `Action execution response for swap ${id}`,
             executionResult
           );
@@ -219,8 +218,7 @@ const config = Config.fromFile(CONFIG_PATH);
 
   setInterval(() => {
     shoot().then(() =>
-      logger.log(
-        "trace",
+      logger.debug(
         `Polling new information from comit-node in ${pollIntervalMillis} ms again`
       )
     );

--- a/src/ledger.ts
+++ b/src/ledger.ts
@@ -14,7 +14,7 @@ export function toLedger(ledger: string) {
     case Ledger.Ethereum:
       return Ledger.Ethereum;
     default:
-      logger.crit(`Ledger not supported: ${ledger}`);
+      logger.error(`Ledger not supported: ${ledger}`);
       return undefined;
   }
 }

--- a/src/ledgerExecutor.ts
+++ b/src/ledgerExecutor.ts
@@ -66,7 +66,7 @@ export class LedgerExecutor {
   }
 
   public async execute(action: LedgerAction) {
-    logger.log("trace", "Execute Ledger Action:", action);
+    logger.debug("Execute Ledger Action:", action);
     try {
       const network = action.payload.network;
       switch (action.type) {

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -5,14 +5,6 @@ import defaultLoggingConf from "../../logconfig.json";
 export function getLogger(config: any = defaultLoggingConf) {
   const logger = winston.createLogger({
     level: config.level,
-    levels: {
-      fatal: 0,
-      crit: 1,
-      warn: 2,
-      info: 3,
-      debug: 4,
-      trace: 5
-    },
     format: winston.format.combine(
       winston.format.timestamp({
         format: "YYYY-MM-DD HH:mm:ss"

--- a/src/rates/testnetMarketMaker.ts
+++ b/src/rates/testnetMarketMaker.ts
@@ -126,7 +126,7 @@ export default class TestnetMarketMaker implements TradeService {
       sell.quantity
     );
     if (!sufficientFunds) {
-      logger.crit(
+      logger.error(
         `Insufficient funds for asset, current balance is ${await this.balances.getBalance(
           sell.asset
         )} but trade requires ${sell.quantity}`,

--- a/src/rates/tradeService.ts
+++ b/src/rates/tradeService.ts
@@ -70,7 +70,7 @@ export async function createTradeEvaluationService({
           return bitcoinWallet.getNominalBalance();
         }
       } catch (e) {
-        logger.crit("Bitcoin balance not found", e);
+        logger.error("Bitcoin balance not found", e);
       }
 
       return Promise.resolve(new Big(0));
@@ -81,7 +81,7 @@ export async function createTradeEvaluationService({
         try {
           return ethereumWallet.getBalance(Asset.ether);
         } catch (e) {
-          logger.crit("Ethereum balance not found", e);
+          logger.error("Ethereum balance not found", e);
         }
       }
       return Promise.resolve(new Big(0));

--- a/src/routes/offersToPublish.ts
+++ b/src/routes/offersToPublish.ts
@@ -65,7 +65,7 @@ export function getOffersToPublishRoute(
 ) {
   return async (_: Request, res: Response) => {
     const errorHandling = (response: Response, message: string) => {
-      logger.crit(`Error when requesting trades to publish: ${message}`);
+      logger.error(`Error when requesting trades to publish: ${message}`);
       response.status(500);
       response.send({ error: message });
     };

--- a/src/wallets/bitcoin.ts
+++ b/src/wallets/bitcoin.ts
@@ -114,7 +114,7 @@ export class InternalBitcoinWallet implements BitcoinWallet {
       network: this.network
     }).address;
     if (!address) {
-      logger.crit(
+      logger.error(
         `Address could not be derived for derivationType`,
         derivationType
       );
@@ -194,7 +194,7 @@ export class InternalBitcoinWallet implements BitcoinWallet {
     logger.debug("Fee (sats):", fee);
 
     if (!inputs || !outputs) {
-      logger.crit(
+      logger.error(
         `Was not able to fund the transaction [address: ${address}, amountSat ${amount}, feeSatPerByte ${feeSatPerByte}]`
       );
       throw new Error("Was not able to fund the transaction");
@@ -262,13 +262,13 @@ export class InternalBitcoinWallet implements BitcoinWallet {
   private getPrivateKey(address: string) {
     const res = this.usedAddresses[address];
     if (!res) {
-      logger.crit(`Cannot find address ${address}`);
+      logger.error(`Cannot find address ${address}`);
       throw new Error(`Cannot find id of input's address ${address}`);
     }
     const hd = this.deriveForId(res);
     const key = hd.privateKey;
     if (!key) {
-      logger.crit(
+      logger.error(
         `Private key of freshly derived pair for address ${address} is undefined`
       );
       throw new Error(

--- a/src/wallets/ethereum.ts
+++ b/src/wallets/ethereum.ts
@@ -65,7 +65,7 @@ export class Web3EthereumWallet implements EthereumWallet {
       .privateKey;
 
     if (!privateKey) {
-      logger.crit(
+      logger.error(
         `Freshly derived HD key does not have the private key`,
         ethereumConfig,
         seed,


### PR DESCRIPTION
google-stackdriver logging does not support winsont's log levels like `crit` or `trace`.. hence I opted for using the [npm defaults](https://github.com/winstonjs/winston#logging-levels) which are 
```
{ 
  error: 0, 
  warn: 1, 
  info: 2, 
  verbose: 3, 
  debug: 4, 
  silly: 5 
}
```

I also had to change `trace` to `debug` which is OK in my opinion. 

Note: this is a bug because on gcloud bobtimus crashed if it tried to print something on an unsupported log level. 